### PR TITLE
Checking typeof to avoid error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function posix(path) {
-	return path.charAt(0) === '/';
+	return typeof path === 'string' && path.charAt(0) === '/';
 }
 
 function win32(path) {


### PR DESCRIPTION
Trying to run gulp on a yeoman generator I got:

```
/home/ezequiel/Escritorio/DEV/ES6/node_modules/path-is-absolute/index.js:4
        return path.charAt(0) === '/';
                    ^

TypeError: path.charAt is not a function
```

and it seems that an object was assigned to the **path** variable due to a wrong configuration and it caused the error.

I added a typeof check to avoid this problem. Also I ran the test before making this pull request.

Any comment or suggestions is welcome (it's my first pull request, so I won't be surprised if I'd miss a step)

