### PR TITLE
Improve the regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ function posix(path) {
 
 function win32(path) {
 	// https://github.com/nodejs/node/blob/b3fcc245fb25539909ef1d5eaa01dbf92e168633/lib/path.js#L56
-	var splitDeviceRe = /^([a-zA-Z]:|[\\\/]{2}[^\\\/]+[\\\/]+[^\\\/]+)?([\\\/])?([\s\S]*?)$/;
+	var splitDeviceRe = /^([a-zA-Z]:|[\\/]{2}[^\\/]+[\\/]+[^\\/]+)?([\\/])?([\s\S]*?)$/;
 	var result = splitDeviceRe.exec(path);
 	var device = result[1] || '';
 	var isUnc = Boolean(device && device.charAt(1) !== ':');


### PR DESCRIPTION
Correcting the regex, which started popping up just as ESLint 4.0.0 was released.

Fix: When inside `[  ]`, you do not need to use `\` for special characters, only when you want symbol `\` itself you need to do double `\\`.